### PR TITLE
add ACL section to config to fix 404 error on config screen

### DIFF
--- a/app/code/community/Quafzi/ExportFullImagePath/etc/config.xml
+++ b/app/code/community/Quafzi/ExportFullImagePath/etc/config.xml
@@ -40,5 +40,24 @@
                 </Quafzi_ExportFullImagePath>
             </modules>
         </translate>
+        <acl>
+            <resources>
+                <admin>
+                    <children>
+                        <system>
+                            <children>
+                                <config>
+                                    <children>
+                                        <exportcsv>
+                                            <title>Export Full Image Paths Module Section</title>
+                                        </exportcsv>
+                                    </children>
+                                </config>
+                            </children>
+                        </system>
+                    </children>
+                </admin>
+            </resources>
+        </acl>
     </adminhtml>
 </config>


### PR DESCRIPTION
Fixes 404 error when trying to access config page under System > Configuration
